### PR TITLE
Added debug JVM args to the main/test commands when called with a prefix argument, and some misc fixes

### DIFF
--- a/eglot-java.el
+++ b/eglot-java.el
@@ -675,7 +675,8 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
 (defun eglot-java-run-test ()
   "Run a test class."
   (interactive)
-  (let* ((fqcn                 (or (eglot-java--find-nearest-method-at-point) (eglot-java--class-fqcn)))
+  (let* ((default-directory    (project-root (project-current t)))
+         (fqcn                 (or (eglot-java--find-nearest-method-at-point) (eglot-java--class-fqcn)))
          (cp                   (eglot-java--project-classpath (buffer-file-name) "test"))
          (current-file-is-test (not (equal ':json-false (eglot-java--file--test-p (buffer-file-name))))))
     (unless (file-exists-p (expand-file-name eglot-java-junit-platform-console-standalone-jar))
@@ -698,8 +699,9 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
 (defun eglot-java-run-main ()
   "Run a main class."
   (interactive)
-  (let* ((fqcn (eglot-java--class-fqcn))
-         (cp   (eglot-java--project-classpath (buffer-file-name) "runtime")))
+  (let* ((default-directory (project-root (project-current t)))
+         (fqcn              (eglot-java--class-fqcn))
+         (cp                (eglot-java--project-classpath (buffer-file-name) "runtime")))
     (if fqcn
         (compile
          (concat (eglot-java--find-java-program-from-alternatives)

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -947,7 +947,7 @@ debug mode."
   "Start a compilation from a direction INITIAL-DIR with a given command string CMD and its arguments string ARGS."
   (let ((mvn-cmd           (concat cmd " " args))
         (default-directory initial-dir))
-    (compile mvn-cmd)))
+    (compile mvn-cmd t)))
 
 (defun eglot-java--build-executable(cmd cmd-wrapper-name cmd-wrapper-dir)
   "Return the command to run, either the initial command itself CMD or its wrapper equivalent (CMD-WRAPPER-NAME) if found in CMD-WRAPPER-DIR."

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -686,6 +686,7 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
          (concat (eglot-java--find-java-program-from-alternatives)
                  " -jar "
                  "\"" (expand-file-name eglot-java-junit-platform-console-standalone-jar) "\""
+                 " execute "
                  (if (string-match-p "#" fqcn)
                      " -m "
                    " -c ")

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -679,7 +679,8 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
     (eglot-java--record-version-info download-version version-file)))
 
 (defun eglot-java-run-test (debug)
-  "Run a test class."
+  "Run a test class or method (at point). With a prefix argument the
+JVM is started in debug mode."
   (interactive "P")
   (let* ((default-directory    (project-root (project-current t)))
          (fqcn                 (or (eglot-java--find-nearest-method-at-point) (eglot-java--class-fqcn)))

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -700,8 +700,7 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
                  fqcn
                  " -class-path "
                  "\"" (mapconcat #'identity cp path-separator) "\""
-                 " ")
-         t)
+                 " "))
       (user-error "No test found in current file! Is the file saved?"))))
 
 (defun eglot-java-run-main (debug)
@@ -717,8 +716,7 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
                  " -cp "
                  "\"" (mapconcat #'identity cp path-separator) "\""
                  " "
-                 fqcn)
-         t)
+                 fqcn))
       (user-error "No main method found in this file! Is the file saved?"))))
 
 (defun eglot-java--class-fqcn ()

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -908,7 +908,7 @@ METADATA-XML-URL is the Maven URL containing a maven-metadata.xml file for the a
   "Start a compilation from a direction INITIAL-DIR with a given command string CMD and its arguments string ARGS."
   (let ((mvn-cmd           (concat cmd " " args))
         (default-directory initial-dir))
-    (compile mvn-cmd t)))
+    (compile mvn-cmd)))
 
 (defun eglot-java--build-executable(cmd cmd-wrapper-name cmd-wrapper-dir)
   "Return the command to run, either the initial command itself CMD or its wrapper equivalent (CMD-WRAPPER-NAME) if found in CMD-WRAPPER-DIR."

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -995,12 +995,12 @@ debug mode."
          (build-cmd                 (if project-is-gradle-project
                                         (eglot-java--build-executable "gradle" "gradlew" project-dir)
                                       (eglot-java--build-executable "mvn" "mvnw" project-dir))))
-    (async-shell-command (format "%s %s %s %s"
-                                 build-cmd
-                                 build-filename-flag
-                                 (shell-quote-argument
-                                  (expand-file-name build-filename project-dir))
-                                 goal))))
+    (compile (format "%s %s %s %s"
+                     build-cmd
+                     build-filename-flag
+                     (shell-quote-argument
+                      (expand-file-name build-filename project-dir))
+                     goal))))
 
 (defun eglot-java--read-json-from-url (url)
   "Fetch the LSP server download metadata in JSON format.


### PR DESCRIPTION
Hi @yveszoundi ,

Sorry for tangling up the following four proposed changes. Let me know if you prefer separate PRs.

### 1. Project pathing fixes
Fix for compile commands not being started in the project root, which is an issue with eg. test resources being unfindable.

### 2. Debugging support
If a user now calls the `eglot-java-run-test` or `eglot-java-run-main` commands with a prefix argument, the functions add the necessary JVM arguments to start the JVM in debug mode. For user configurability I added a custom variable with these args by default: `"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:8000"`

With the debugger started, a user can then use eg. `dape` to attach to the debugger and debug tests or main classes :-)

My `dape` config to make this work looks like the following:
```
(use-package dape
  :if (package-installed-p 'dape)
  :after eglot
  :config
  (add-to-list 'dape-configs
	       `(jdtls
		 modes (java-mode java-ts-mode)
		 hostname "localhost"
		 port (lambda () (eglot-execute-command (eglot-current-server)
							"vscode.java.startDebugSession" nil))
                 :request "attach"
		 :hostname "localhost"
		 :port 8000
		 :type "java")))
```
That also require the java-debug-server extension bundle to be added to `jdtls` like so (you also document this in your module).
```
(defun my/eglot-java-init-opts (server eglot-java-eclipse-jdt)
    (:bundles ["/PATH/TO/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-VERSION.jar"]))
(setopt eglot-java-user-init-opts-fn #'my/eglot-java-init-opts)
```

### 3. Changed the calls to `compile` to not set COMINT mode. The benefit is that the compilation buffer then allows the user to bury it easily (`q`) or re-run it (`g`).

### 4. Use the execute command in the call to JUnit console to silence the deprecation message.

