### PR TITLE
file-new: Allow skipping class type, preload package name

### DIFF
--- a/eglot-java.el
+++ b/eglot-java.el
@@ -540,13 +540,10 @@ Otherwise the basename of the folder ROOT will be returned."
                                             (json-encode `(("scope" . ,scope)))))
              :classpaths))
 
-(defun eglot-java--buffer-package-name ()
+(defun eglot-java--class-package ()
   "Get the Java package name of the current buffer, or `nil' if it is not
 present."
-  (save-excursion
-    (goto-char (point-min))
-    (when (re-search-forward "^package \\(.+\\);" nil t)
-      (match-string-no-properties 1))))
+  (eglot-java--symbol-name-for-type (eglot-java--document-symbols) "Package"))
 
 (defun eglot-java-file-new ()
   "Create a new class."
@@ -572,7 +569,7 @@ import org.junit.jupiter.api.Test;\n\npublic class %s {\n\n}")))
                                     source-paths))
          (selected-path     (completing-read "Source path : " display-paths))
          (fqcn              (read-string "Class name: "
-                                         (if-let ((package (eglot-java--buffer-package-name)))
+                                         (if-let ((package (eglot-java--class-package)))
                                              (concat package "."))))
          (class-type        (when eglot-java-file-new-ask-type
                                 (completing-read "Type: " (hash-table-keys class-by-type))))

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -219,6 +219,12 @@
   :type 'string
   :group 'eglot-java)
 
+(defcustom eglot-java-file-new-ask-type t
+  "Whether `eglot-java-file-new' asks for the type of new file, or inserts only
+the package name."
+  :type 'boolean
+  :group 'eglot-java)
+
 (defconst eglot-java-filename-build-maven            "pom.xml"                   "Maven build file name.")
 (defconst eglot-java-filename-build-gradle-groovy    "build.gradle"              "Gradle build file name with Groovy.")
 (defconst eglot-java-filename-build-gradle-kotlin    "build.gradle.kts"          "Gradle build file name with Kotlin.")
@@ -558,7 +564,8 @@ import org.junit.jupiter.api.Test;\n\npublic class %s {\n\n}")))
                                     source-paths))
          (selected-path     (completing-read "Source path : " display-paths))
          (fqcn              (read-string "Class name: "))
-         (class-type        (completing-read "Type: " (hash-table-keys class-by-type)))
+         (class-type        (when eglot-java-file-new-ask-type
+                                (completing-read "Type: " (hash-table-keys class-by-type))))
          (selected-source   (car (cl-remove-if-not
                                   (lambda (e)
                                     (string= (plist-get e :displayPath) selected-path))
@@ -578,8 +585,9 @@ import org.junit.jupiter.api.Test;\n\npublic class %s {\n\n}")))
     (save-buffer)
     (when new-paths
       (insert "package " (mapconcat #'identity new-paths ".") ";\n\n"))
-    (insert (format (gethash class-type class-by-type)
-                    simple-class-name))
+    (when class-type
+      (insert (format (gethash class-type class-by-type)
+                      simple-class-name)))
     (save-buffer)))
 
 (defun eglot-java--do-find-nearest-class-at-point (acc syms idx elt-type cursor-location)

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -540,6 +540,14 @@ Otherwise the basename of the folder ROOT will be returned."
                                             (json-encode `(("scope" . ,scope)))))
              :classpaths))
 
+(defun eglot-java--buffer-package-name ()
+  "Get the Java package name of the current buffer, or `nil' if it is not
+present."
+  (save-excursion
+    (goto-char (point-min))
+    (when (re-search-forward "^package \\(.+\\);" nil t)
+      (match-string-no-properties 1))))
+
 (defun eglot-java-file-new ()
   "Create a new class."
   (interactive)
@@ -563,7 +571,9 @@ import org.junit.jupiter.api.Test;\n\npublic class %s {\n\n}")))
                                       (plist-get e :displayPath))
                                     source-paths))
          (selected-path     (completing-read "Source path : " display-paths))
-         (fqcn              (read-string "Class name: "))
+         (fqcn              (read-string "Class name: "
+                                         (if-let ((package (eglot-java--buffer-package-name)))
+                                             (concat package "."))))
          (class-type        (when eglot-java-file-new-ask-type
                                 (completing-read "Type: " (hash-table-keys class-by-type))))
          (selected-source   (car (cl-remove-if-not

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -541,7 +541,7 @@ Otherwise the basename of the folder ROOT will be returned."
              :classpaths))
 
 (defun eglot-java--class-package ()
-  "Get the Java package name of the current buffer, or `nil' if it is not
+  "Get the Java package name of the current buffer, or empty string if it is not
 present."
   (eglot-java--symbol-name-for-type (eglot-java--document-symbols) "Package"))
 
@@ -569,8 +569,9 @@ import org.junit.jupiter.api.Test;\n\npublic class %s {\n\n}")))
                                     source-paths))
          (selected-path     (completing-read "Source path : " display-paths))
          (fqcn              (read-string "Class name: "
-                                         (if-let ((package (eglot-java--class-package)))
-                                             (concat package "."))))
+                                         (let ((package (eglot-java--class-package)))
+                                           (unless (string-empty-p package)
+                                             (concat package ".")))))
          (class-type        (when eglot-java-file-new-ask-type
                                 (completing-read "Type: " (hash-table-keys class-by-type))))
          (selected-source   (car (cl-remove-if-not


### PR DESCRIPTION
* New option `eglot-java-file-new-ask-type`: when nil, skip asking for the class type and don't insert a class block into the new file.
* Preload the package name from the current file in the class name prompt.