### PR TITLE
Call JUnit console by its class rather than with jar

### DIFF
--- a/eglot-java.el
+++ b/eglot-java.el
@@ -727,12 +727,12 @@ JVM is started in debug mode."
                    (when debug (concat " " eglot-java-debug-jvm-arg))
                    " "
                    (mapconcat #'identity eglot-java-run-test-jvm-args " ")
-		   " -cp "
+                   " -cp "
                    "\""
-		   (mapconcat #'identity cp path-separator) path-separator
-		   (expand-file-name eglot-java-junit-platform-console-standalone-jar)
-		   "\""
-		   " org.junit.platform.console.ConsoleLauncher"
+                   (mapconcat #'identity cp path-separator) path-separator
+                   (expand-file-name eglot-java-junit-platform-console-standalone-jar)
+                   "\""
+                   " org.junit.platform.console.ConsoleLauncher"
                    " execute "
                    (if (string-match-p "#" fqcn)
                        " -m "

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -727,15 +727,17 @@ JVM is started in debug mode."
                    (when debug (concat " " eglot-java-debug-jvm-arg))
                    " "
                    (mapconcat #'identity eglot-java-run-test-jvm-args " ")
-                   " -jar "
-                   "\"" (expand-file-name eglot-java-junit-platform-console-standalone-jar) "\""
+		   " -cp "
+                   "\""
+		   (mapconcat #'identity cp path-separator) path-separator
+		   (expand-file-name eglot-java-junit-platform-console-standalone-jar)
+		   "\""
+		   " org.junit.platform.console.ConsoleLauncher"
                    " execute "
                    (if (string-match-p "#" fqcn)
                        " -m "
                      " -c ")
-                   fqcn
-                   " -class-path "
-                   "\"" (mapconcat #'identity cp path-separator) "\"")))
+                   fqcn)))
       (user-error "No test found in current file! Is the file saved?"))))
 
 (defun eglot-java-run-main (debug)

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -729,8 +729,9 @@ JVM is started in debug mode."
                    (mapconcat #'identity eglot-java-run-test-jvm-args " ")
                    " -cp "
                    "\""
-                   (mapconcat #'expand-file-name cp path-separator) path-separator
                    (expand-file-name eglot-java-junit-platform-console-standalone-jar)
+                   path-separator
+                   (mapconcat #'expand-file-name cp path-separator)
                    "\""
                    " org.junit.platform.console.ConsoleLauncher"
                    " execute"

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -729,11 +729,11 @@ JVM is started in debug mode."
                    (mapconcat #'identity eglot-java-run-test-jvm-args " ")
                    " -cp "
                    "\""
-                   (mapconcat #'identity cp path-separator) path-separator
+                   (mapconcat #'expand-file-name cp path-separator) path-separator
                    (expand-file-name eglot-java-junit-platform-console-standalone-jar)
                    "\""
                    " org.junit.platform.console.ConsoleLauncher"
-                   " execute "
+                   " execute"
                    (if (string-match-p "#" fqcn)
                        " -m "
                      " -c ")
@@ -755,7 +755,7 @@ debug mode."
                    " "
                    (mapconcat #'identity eglot-java-run-main-jvm-args " ")
                    " -cp "
-                   "\"" (mapconcat #'identity cp path-separator) "\""
+                   "\"" (mapconcat #'expand-file-name cp path-separator) "\""
                    " "
                    fqcn
                    " "


### PR DESCRIPTION
Hi @yveszoundi another small PR :-) 

Calling the JUnit console with -jar leads to issues with test resources (in eg. src/test/resources) being searched for inside the JUnit console jar. With this PR, the class path is set for the JVM including the console jar, then the JUnit console main class is executed. This avoids the issue.