### PR TITLE
Revert JUnit console running back to running as jar

### DIFF
--- a/eglot-java.el
+++ b/eglot-java.el
@@ -728,9 +728,9 @@ JVM is started in debug mode."
                    (mapconcat #'identity eglot-java-run-test-jvm-args " ")
                    " -cp "
                    "\""
-                   (expand-file-name eglot-java-junit-platform-console-standalone-jar)
-                   path-separator
                    (mapconcat #'expand-file-name cp path-separator)
+                   path-separator
+                   (expand-file-name eglot-java-junit-platform-console-standalone-jar)
                    "\""
                    " org.junit.platform.console.ConsoleLauncher"
                    " execute"

--- a/eglot-java.el
+++ b/eglot-java.el
@@ -726,18 +726,20 @@ JVM is started in debug mode."
                    (when debug (concat " " eglot-java-debug-jvm-arg))
                    " "
                    (mapconcat #'identity eglot-java-run-test-jvm-args " ")
-                   " -cp "
+                   " -jar "
                    "\""
-                   (mapconcat #'expand-file-name cp path-separator)
-                   path-separator
                    (expand-file-name eglot-java-junit-platform-console-standalone-jar)
                    "\""
-                   " org.junit.platform.console.ConsoleLauncher"
                    " execute"
                    (if (string-match-p "#" fqcn)
                        " -m "
                      " -c ")
-                   fqcn)))
+                   fqcn
+                   " -cp "
+                   "\""
+                   (mapconcat #'expand-file-name cp path-separator)
+                   "\""
+                   )))
       (user-error "No test found in current file! Is the file saved?"))))
 
 (defun eglot-java-run-main (debug)


### PR DESCRIPTION
@yveszoundi After some trouble it seems the JUnit standalone jar should be loaded last on the classpath, after all. The reason is with loading test resources, which the JUnit standalone console seems to interfere with. If the JUnit jar is loaded first, test resources will be searched within the JUnit jar. This PR reverses the earlier change.